### PR TITLE
tailwindcssの結合用関数を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,14 @@
         "@clerk/nextjs": "^5.2.6",
         "@prisma/client": "^5.17.0",
         "@supabase/supabase-js": "^2.44.4",
+        "clsx": "^2.1.1",
         "lucide-react": "^0.414.0",
         "next": "14.2.5",
         "react": "^18",
         "react-dom": "^18",
         "svix": "^1.25.0",
         "swr": "^2.2.5",
+        "tailwind-merge": "^2.4.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -1443,6 +1445,14 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -5255,6 +5265,15 @@
       },
       "peerDependencies": {
         "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.4.0.tgz",
+      "integrity": "sha512-49AwoOQNKdqKPd9CViyH5wJoSKsCDjUlzL8DxuGp3P1FsGY36NJDAa18jLZcaHAUUuTj+JB8IAo8zWgBNvBF7A==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -14,12 +14,14 @@
     "@clerk/nextjs": "^5.2.6",
     "@prisma/client": "^5.17.0",
     "@supabase/supabase-js": "^2.44.4",
+    "clsx": "^2.1.1",
     "lucide-react": "^0.414.0",
     "next": "14.2.5",
     "react": "^18",
     "react-dom": "^18",
     "svix": "^1.25.0",
     "swr": "^2.2.5",
+    "tailwind-merge": "^2.4.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export const cn = (...inputs: ClassValue[]) => {
+  return twMerge(clsx(inputs));
+};


### PR DESCRIPTION
tailwindcssのスタイルを簡単に動的に書いたり、コンポーネントにあらかじめ定義されたスタイルとコンポーネントを呼び出すときに定義したスタイルの重複を自動で解決する

参考:
<https://github.com/dcastil/tailwind-merge>
<https://github.com/lukeed/clsx>

Closes #28 