### PR TITLE
マイグレーション用のDBのURLをスキーマで受け取るように変更

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,7 +11,7 @@ generator client {
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
-  
+  directUrl = env("DIRECT_URL")
 }
 
 


### PR DESCRIPTION
環境変数はそのままでも動きますが、`DATABASE_URL`の末尾に`?pgbouncer=true`をつけて`DIRECT_URL`はパラメーターをなしにすると良いです。

Closes #53 