### PR TITLE
空白のみで検索された場合`/timeline/all`に遷移させる

### DIFF
--- a/src/components/layout/RightSideBar.tsx
+++ b/src/components/layout/RightSideBar.tsx
@@ -9,8 +9,11 @@ const RightSideBar = () => {
   const handleKeyInput = (event: React.KeyboardEvent) => {
     const key = event.key;
     console.log(searchInput);
-    if (key === 'Enter') {
+    if (key === 'Enter' && searchInput.trim() !== '') {
       router.push(`/timeline/search/${searchInput}`);
+    } else if (key === 'Enter' && searchInput.trim() === '') {
+      // 空白の場合は/timeline/allに遷移
+      router.push(`/timeline/all`);
     }
     return;
   };


### PR DESCRIPTION
`trim()`時の内容が空だったときは`/timeline/all`に遷移
Closes #170
