### PR TITLE
postgresのdocker-composeを作成

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,15 @@
+services:
+  db:
+    image: postgres:latest
+    container_name: postgres_db
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    ports:
+      - '5432:5432'
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+
+volumes:
+  pg_data:


### PR DESCRIPTION
今のところ使わなくてOK

Related: #172 

ローカル用DB変数
```env
DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres"
DIRECT_URL="postgresql://postgres:postgres@localhost:5432/postgres"
```
ローカルに切り替えたら`npx prisma db push`
